### PR TITLE
Create Docker armhf variant for Raspberry Pi and mobile users

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,0 +1,35 @@
+## Builder image
+FROM arm32v7/golang:1.14-alpine AS builder
+
+RUN apk add --no-cache ca-certificates git
+
+WORKDIR /src
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 go build -o /dist/hera
+
+## Final image
+FROM arm32v7/alpine:3.11
+
+RUN apk add --no-cache ca-certificates curl
+
+RUN curl -L -s https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-armhf.tar.gz \
+  | tar xvzf - -C /
+
+RUN curl -L -s https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-arm.tgz \
+  | tar xvzf - -C /bin
+
+RUN mkdir /lib64 && ln -s /lib/libc.musl-armhf.so.1 /lib64/ld-linux-armhf.so.2
+
+RUN apk del --no-cache curl
+
+COPY --from=builder /dist/hera /bin/
+
+COPY rootfs /
+
+ENTRYPOINT ["/init"]

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -11,20 +11,19 @@ RUN go mod download
 
 COPY . .
 
+# not needed GOARCH=arm GOARM=7, it will be auto-set correctly if building on the target machine
 RUN CGO_ENABLED=0 go build -o /dist/hera
 
 ## Final image
 FROM arm32v7/alpine:3.11
 
-RUN apk add --no-cache ca-certificates curl
+RUN apk add --no-cache ca-certificates curl gcompat
 
 RUN curl -L -s https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-armhf.tar.gz \
   | tar xvzf - -C /
 
 RUN curl -L -s https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-arm.tgz \
   | tar xvzf - -C /bin
-
-RUN mkdir /lib64 && ln -s /lib/libc.musl-armhf.so.1 /lib64/ld-linux-armhf.so.2
 
 RUN apk del --no-cache curl
 


### PR DESCRIPTION
Not sure if there's a better way to do multi-arch support, so I just created a separate `Dockerfile.armhf`.

Usage:
```bash
docker build --file Dockerfile.armhf --tag hera:armhf
docker run \
  --name=hera \
  --network=hera \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -v /path/to/certs:/certs \
  hera:armhf
```
or with `docker-compose`:
```yaml
services:
    hera:
        build:
            context: .
            dockerfile: Dockerfile.armhf
        image: hera:armhf
        ...
```

I also took the liberty of bumping a few of the dependency versions in the process (go, cloudflared, alpine, overlay).

Testing on a Raspberry Pi 4 with raspian:


![image](https://user-images.githubusercontent.com/511499/78667065-4eca3380-78a6-11ea-8ebe-61938e42827b.png)
![image](https://user-images.githubusercontent.com/511499/78666291-2261e780-78a5-11ea-8d07-d0388331be4d.png)

```logs
root@unifipi /o/ubuntu.hera# docker-compose build
Building hera
Step 1/16 : FROM arm32v7/golang:1.14-alpine AS builder
 ---> e480d1e4bcd0
Step 2/16 : RUN apk add --no-cache ca-certificates git
 ---> Using cache
 ---> d6317c6ed7e5
Step 3/16 : WORKDIR /src
 ---> Using cache
 ---> 4311b67a5a43
Step 4/16 : COPY go.mod .
 ---> Using cache
 ---> 23d9b04c888b
Step 5/16 : COPY go.sum .
 ---> Using cache
 ---> fc1680583234
Step 6/16 : RUN go mod download
 ---> Using cache
 ---> b98fb52b443f
Step 7/16 : COPY . .
 ---> c7959559b009
Step 8/16 : RUN CGO_ENABLED=0 go build -o /dist/hera
 ---> Running in 8e7ce0866b06
Removing intermediate container 8e7ce0866b06
 ---> 09b51519e08a
Step 9/16 : FROM arm32v7/alpine:3.11
 ---> 0d8bd234c4c8
Step 10/16 : RUN apk add --no-cache ca-certificates curl gcompat
 ---> Using cache
 ---> 61a3b95558e4
Step 11/16 : RUN curl -L -s https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-armhf.tar.gz   | tar xvzf - -C /
 ---> Using cache
 ---> e5e6fab09960
Step 12/16 : RUN curl -L -s https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-arm.tgz   | tar xvzf - -C /bin
 ---> Using cache
 ---> e95a4d93adad
Step 13/16 : RUN apk del --no-cache curl
 ---> Using cache
 ---> ce6807792338
Step 14/16 : COPY --from=builder /dist/hera /bin/
 ---> Using cache
 ---> e1a566a193fa
Step 15/16 : COPY rootfs /
 ---> 93e26e1ceecc
Step 16/16 : ENTRYPOINT ["/init"]
 ---> Running in b3fdaedd6389
Removing intermediate container b3fdaedd6389
 ---> b07ec77267d3
Successfully built b07ec77267d3
Successfully tagged hera:armhf
```
```logs
root@unifipi /o/ubuntu.hera# docker-compose up
Recreating hera ... done
Attaching to hera
hera    | [s6-init] making user provided files available at /var/run/s6/etc...exited 0.
hera    | [s6-init] ensuring user provided files have correct perms...exited 0.
hera    | [fix-attrs.d] applying ownership & permissions fixes...
hera    | [fix-attrs.d] 01-log-permissions: applying...
hera    | [fix-attrs.d] 01-log-permissions: exited 0.
hera    | [fix-attrs.d] done.
hera    | [cont-init.d] executing container initialization scripts...
hera    | [cont-init.d] 01-setup-logs: executing...
hera    | [cont-init.d] 01-setup-logs: exited 0.
hera    | [cont-init.d] 02-symlink-certs: executing...
hera    | [cont-init.d] 02-symlink-certs: exited 0.
hera    | [cont-init.d] done.
hera    | [services.d] starting services
hera    | [services.d] done.
hera    | [INFO] Hera v0.2.5 has started
hera    | [INFO] Found certificate: zervice.io.pem
hera    | [INFO] Hera is listening
hera    | [INFO] Container found, connecting to fe6e88256c13...
hera    | [INFO] Registering tunnel unifi.zervice.io
```